### PR TITLE
[Feature] Remove dialog for GMs when there are active owners of a character

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -1,6 +1,7 @@
 import dialog from './dialog.html';
 
 import { processDamage, log } from '../utils';
+import { checkShouldShowDialog } from '../user-identity/user-identity';
 
 const TEMPLATE = 'modules/prompt-inflict-damage/dist/dialog.html';
 
@@ -8,9 +9,11 @@ export async function showInfo({ total, target }) {
 	const actor = target.actor;
 	const isOwner = actor.owner;
 
-	log(actor.permission)
-
-	if (!isOwner || !actor?.data?.data?.attributes?.hp?.value) {
+	if (
+		!isOwner ||
+		!actor?.data?.data?.attributes?.hp?.value ||
+		!checkShouldShowDialog(target)
+	) {
 		return;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { inflictDamage } from './inflict-damage';
-import { log } from './utils';
 
 let isReady = false;
 
@@ -8,8 +7,6 @@ Hooks.on('ready', () => {
 });
 
 Hooks.on("renderChatMessage", (app, html, data) => {
-	log({ game, canvas })
-	log(game.users.get(game.userId).character)
 	if (isReady) {
 		inflictDamage({app, data});
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { inflictDamage } from './inflict-damage';
+import { log } from './utils';
 
 let isReady = false;
 
@@ -7,6 +8,8 @@ Hooks.on('ready', () => {
 });
 
 Hooks.on("renderChatMessage", (app, html, data) => {
+	log({ game, canvas })
+	log(game.users.get(game.userId).character)
 	if (isReady) {
 		inflictDamage({app, data});
 	}

--- a/src/user-identity/user-identity.js
+++ b/src/user-identity/user-identity.js
@@ -1,0 +1,36 @@
+function checkHasOwnerOtherThanGm(currentUser, targetId) {
+	const actor = game?.actors?.get(targetId);
+
+	// no-op
+	if (!actor) {
+		return false;
+	}
+
+	// if the current user is the GM, remove GM and default properties and check other permissions
+	const hasNoneGMPermission = Object.keys(actor.data.permission)
+		.filter(perm => perm !== game.userId && perm !== 'default')
+		.filter(perm => actor.data.permission[perm] === 3)
+		.length > 0;
+
+	// check is active
+
+	// if the current user is the GM and
+	// if there are other non-GM users with owner permission
+	return hasNoneGMPermission;
+}
+
+export function checkShouldShowDialog(target) {
+	const targetId = target?.actor?.id;
+	const users = game?.users;
+	const currentUser = users?.get(game.userId);
+
+	if (!targetId || !currentUser) {
+		return true;
+	}
+
+	if (currentUser.isGM && checkHasOwnerOtherThanGm(currentUser, targetId)) {
+		return false;
+	}
+
+	return true;
+}

--- a/src/user-identity/user-identity.js
+++ b/src/user-identity/user-identity.js
@@ -1,4 +1,5 @@
-function checkHasOwnerOtherThanGm(currentUser, targetId) {
+function checkHasOwnerOtherThanGm(targetId) {
+	const users = game?.users;
 	const actor = game?.actors?.get(targetId);
 
 	// no-op
@@ -7,16 +8,23 @@ function checkHasOwnerOtherThanGm(currentUser, targetId) {
 	}
 
 	// if the current user is the GM, remove GM and default properties and check other permissions
-	const hasNoneGMPermission = Object.keys(actor.data.permission)
+	const nonGMPermissionUsers = Object.keys(actor.data.permission)
 		.filter(perm => perm !== game.userId && perm !== 'default')
-		.filter(perm => actor.data.permission[perm] === 3)
+		.filter(perm => actor.data.permission[perm] === 3);
+
+	if (nonGMPermissionUsers.length === 0) {
+		return false;
+	}
+
+	// check any remaining owners are active
+	const hasNonGMPermissionInGame = nonGMPermissionUsers
+		.filter(permUser => users.get(permUser).active)
 		.length > 0;
 
-	// check is active
 
 	// if the current user is the GM and
 	// if there are other non-GM users with owner permission
-	return hasNoneGMPermission;
+	return hasNonGMPermissionInGame;
 }
 
 export function checkShouldShowDialog(target) {
@@ -28,7 +36,7 @@ export function checkShouldShowDialog(target) {
 		return true;
 	}
 
-	if (currentUser.isGM && checkHasOwnerOtherThanGm(currentUser, targetId)) {
+	if (currentUser.isGM && checkHasOwnerOtherThanGm(targetId)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Changes
- Added check to see if the targeted character has other owners in case the current user is the GM
- Added check to see if the other users that own a character are active

## Reason and context
Previously the GM would see prompts for damage done to any character they own (everyone).
Now we check if the GM is the only active owner in game before showing the prompt to them