### PR TITLE
[Bugfix] Remove permissions not tied to existing user

### DIFF
--- a/src/user-identity/user-identity.js
+++ b/src/user-identity/user-identity.js
@@ -18,7 +18,7 @@ function checkHasOwnerOtherThanGm(targetId) {
 
 	// check any remaining owners are active
 	const hasNonGMPermissionInGame = nonGMPermissionUsers
-		.filter(permUser => users.get(permUser).active)
+		.filter(permUser => users.get(permUser)?.active)
 		.length > 0;
 
 


### PR DESCRIPTION
## Changes
- updated filter for active users to shortcircuit in case the permission is not tied to an actual user

## Reason and context
In some games, when there were permissions tied to eliminated users or not to users specifically, an error was thrown